### PR TITLE
Check for image before calling imagecreatefromstring()

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/tonesque.php
+++ b/projects/plugins/jetpack/_inc/lib/tonesque.php
@@ -86,7 +86,10 @@ class Tonesque {
 
 			if ( empty( $data ) ) {
 				$response = wp_safe_remote_get( $image_url );
-				if ( is_wp_error( $response ) ) {
+				if ( 
+					is_wp_error( $response )
+					|| ! wp_startswith( $response['headers']['content-type'], 'image/' )
+				) {
 					return false;
 				}
 				$data = wp_remote_retrieve_body( $response );
@@ -101,6 +104,10 @@ class Tonesque {
 			if ( wp_startswith( $type, 'image/' ) ) {
 				$data = file_get_contents( $image_url ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			}
+		}
+
+		if ( null === $data ) {
+			return false;
 		}
 
 		// Now turn it into an image and return it.


### PR DESCRIPTION
The current code can run into a few conditions where the end result is that `imagecreatefromstring()` is called on something that isn't actually an image.

I found two conditions where that happens.  The first is where we end up with a NULL value at the end.  The second is where a remote image is requested, but what you get back is something else ( like the HTML for an error page ).

This update adds checks to defend against both of those possible error conditions.
